### PR TITLE
Switch from dumb-init to tini

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dockerfiles for base images that make creating correct, minimal images for Pytho
 #### `praekeltfoundation/python-base`
 [![Docker Pulls](https://img.shields.io/docker/pulls/praekeltfoundation/python-base.svg?style=flat-square)](https://hub.docker.com/r/praekeltfoundation/python-base/)
 
-Provides Debian- and Alpine Linux-based Python images with some utility scripts, `dumb-init`, and `gosu`. Also configures `pip` to not use a cache and to use the Praekelt.org Python Package Index. For more information about our Package Index, see [`praekeltfoundation/debian-wheel-mirror`](https://github.com/praekeltfoundation/debian-wheel-mirror).
+Provides Debian- and Alpine Linux-based Python images with some utility scripts, `tini`, and `gosu`. Also configures `pip` to not use a cache and to use the Praekelt.org Python Package Index. For more information about our Package Index, see [`praekeltfoundation/debian-wheel-mirror`](https://github.com/praekeltfoundation/debian-wheel-mirror).
 
 #### `praekeltfoundation/pypy-base`
 [![Docker Pulls](https://img.shields.io/docker/pulls/praekeltfoundation/pypy-base.svg?style=flat-square)](https://hub.docker.com/r/praekeltfoundation/pypy-base/)
@@ -41,7 +41,9 @@ Two simple scripts that wrap `apt-get install` and `apt-get purge` to make it ea
 For a complete explanation of this problem see [this](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/) excellent blog post by Phusion. Suffice to say, many programs expect the system they're running on to have an init system that will manage/clean up child processes but most Docker containers don't have an init system.
 
 ##### Our solution:
-Using a very very simple init system that reaps orphaned child processes and passes through signals to the main process. We use the (badly named) [`dumb-init`](https://github.com/Yelp/dumb-init) by Yelp.
+Using a very very simple init system that reaps orphaned child processes and passes through signals to the main process. We use [`tini`](https://github.com/krallin/tini).
+
+> **Note:** `tini` is built-in and runs by default in Docker 1.13.0+. Once all our infrastructure moves to a new-enough version of Docker, we will remove `tini` from these images.
 
 This program is the default entrypoint for all the images, so using it should be automatic most of the time - simply specify a `CMD []` in your Dockerfile.
 
@@ -75,7 +77,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 `docker-entrypoint.sh`:
 ```shell
-#!/usr/bin/dumb-init /bin/sh
+#!/usr/local/sbin/tini /bin/sh
 # ...
 
 exec su-exec vumi \

--- a/alpine/python/2.7/Dockerfile
+++ b/alpine/python/2.7/Dockerfile
@@ -2,21 +2,21 @@ FROM python:2.7.13-alpine
 LABEL maintainer "Praekelt.org <sre@praekelt.org>"
 
 # Install libffi as it is small and means we get working cffi
-RUN apk add --no-cache \
-        libffi \
-        su-exec
+RUN apk add --no-cache libffi
 
-# Install dinit (dumb-init)
-ENV DINIT_VERSION="1.2.0" \
-    DINIT_SHA256="81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363"
+# Install su-exec and tini
 RUN set -xe; \
-    apk add --no-cache wget; \
-    wget -O dumb-init "https://github.com/Yelp/dumb-init/releases/download/v$DINIT_VERSION/dumb-init_${DINIT_VERSION}_amd64"; \
-    echo "$DINIT_SHA256 *dumb-init" | sha256sum -c -; \
-    chmod +x dumb-init; \
-    mv dumb-init /usr/bin/dumb-init; \
-    ln -s /usr/bin/dumb-init /usr/local/bin/dinit; \
-    apk del wget
+    apk add --no-cache su-exec tini; \
+    mkdir /usr/local/sbin; \
+# Link `su-exec` as `gosu` for compatibility with Debian
+    ln -s "$(which su-exec)" /usr/local/sbin/gosu; \
+# Remove the script at /usr/bin/tini warning that tini is really at /sbin/tini
+    rm /usr/bin/tini; \
+# Link `tini` as `dumb-init` and `dinit` for compatibility with older images
+    ln -s "$(which tini)" /usr/local/sbin/dumb-init; \
+    dumb-init -s -- true; \
+    ln -s "$(which tini)" /usr/local/sbin/dinit; \
+    dinit -s -- true
 
 # pip: Disable cache and use Praekelt Foundation Python Package Index
 ENV PIP_NO_CACHE_DIR="false" \
@@ -26,6 +26,6 @@ ENV PIP_NO_CACHE_DIR="false" \
 COPY scripts /scripts
 ENV PATH $PATH:/scripts
 
-# Set dinit as the default entrypoint
-ENTRYPOINT ["dinit"]
+# Set tini as the default entrypoint
+ENTRYPOINT ["tini"]
 CMD ["python"]

--- a/alpine/python/3.6/Dockerfile
+++ b/alpine/python/3.6/Dockerfile
@@ -2,21 +2,21 @@ FROM python:3.6.1-alpine
 LABEL maintainer "Praekelt.org <sre@praekelt.org>"
 
 # Install libffi as it is small and means we get working cffi
-RUN apk add --no-cache \
-        libffi \
-        su-exec
+RUN apk add --no-cache libffi
 
-# Install dinit (dumb-init)
-ENV DINIT_VERSION="1.2.0" \
-    DINIT_SHA256="81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363"
+# Install su-exec and tini
 RUN set -xe; \
-    apk add --no-cache wget; \
-    wget -O dumb-init "https://github.com/Yelp/dumb-init/releases/download/v$DINIT_VERSION/dumb-init_${DINIT_VERSION}_amd64"; \
-    echo "$DINIT_SHA256 *dumb-init" | sha256sum -c -; \
-    chmod +x dumb-init; \
-    mv dumb-init /usr/bin/dumb-init; \
-    ln -s /usr/bin/dumb-init /usr/local/bin/dinit; \
-    apk del wget
+    apk add --no-cache su-exec tini; \
+    mkdir /usr/local/sbin; \
+# Link `su-exec` as `gosu` for compatibility with Debian
+    ln -s "$(which su-exec)" /usr/local/sbin/gosu; \
+# Remove the script at /usr/bin/tini warning that tini is really at /sbin/tini
+    rm /usr/bin/tini; \
+# Link `tini` as `dumb-init` and `dinit` for compatibility with older images
+    ln -s "$(which tini)" /usr/local/sbin/dumb-init; \
+    dumb-init -s -- true; \
+    ln -s "$(which tini)" /usr/local/sbin/dinit; \
+    dinit -s -- true
 
 # pip: Disable cache and use Praekelt Foundation Python Package Index
 ENV PIP_NO_CACHE_DIR="false" \
@@ -26,6 +26,6 @@ ENV PIP_NO_CACHE_DIR="false" \
 COPY scripts /scripts
 ENV PATH $PATH:/scripts
 
-# Set dinit as the default entrypoint
-ENTRYPOINT ["dinit"]
+# Set tini as the default entrypoint
+ENTRYPOINT ["tini"]
 CMD ["python"]

--- a/debian/pypy/2/Dockerfile
+++ b/debian/pypy/2/Dockerfile
@@ -49,6 +49,6 @@ RUN set -xe; \
     \
     apt-get-purge.sh wget
 
-# Set dinit as the default entrypoint
+# Set tini as the default entrypoint
 ENTRYPOINT ["tini"]
 CMD ["pypy"]

--- a/debian/pypy/2/Dockerfile
+++ b/debian/pypy/2/Dockerfile
@@ -27,9 +27,9 @@ RUN set -xe; \
     gpg --batch --verify gosu.asc gosu; \
     rm -r "$GNUPGHOME" gosu.asc; \
     chmod +x gosu; \
-    mv gosu /usr/local/bin/gosu; \
+    mv gosu /usr/local/sbin/gosu; \
 # Link `gosu` as `su-exec` for compatibility with Alpine Linux
-    ln -s /usr/local/bin/gosu /usr/local/bin/su-exec; \
+    ln -s /usr/local/sbin/gosu /usr/local/sbin/su-exec; \
     su-exec nobody true; \
     \
 # Install tini

--- a/debian/pypy/2/Dockerfile
+++ b/debian/pypy/2/Dockerfile
@@ -12,19 +12,13 @@ RUN update-alternatives --install /usr/bin/python python /usr/local/bin/pypy 50
 COPY scripts /scripts
 ENV PATH $PATH:/scripts
 
-ENV DINIT_VERSION="1.2.0" \
-    DINIT_SHA256="9af7440986893c904f24c086c50846ddc5a0f24864f5566b747b8f1a17f7fd52"
 ENV GOSU_VERSION="1.10" \
-    GOSU_GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4"
+    GOSU_GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    TINI_VERSION="0.14.0" \
+    TINI_GPG_KEY="595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7"
 RUN set -xe; \
     apt-get-install.sh wget; \
-# Install dumb-init
-    wget -O dumb-init.deb "https://github.com/Yelp/dumb-init/releases/download/v$DINIT_VERSION/dumb-init_${DINIT_VERSION}_amd64.deb"; \
-    echo "$DINIT_SHA256 *dumb-init.deb" | sha256sum -c -; \
-    dpkg --install dumb-init.deb; \
-    rm dumb-init.deb; \
-    ln -s $(which dumb-init) /usr/local/bin/dinit; \
-    dinit true; \
+    \
 # Install gosu
     wget -O gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64"; \
     wget -O gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc"; \
@@ -34,10 +28,27 @@ RUN set -xe; \
     rm -r "$GNUPGHOME" gosu.asc; \
     chmod +x gosu; \
     mv gosu /usr/local/bin/gosu; \
+# Link `gosu` as `su-exec` for compatibility with Alpine Linux
     ln -s /usr/local/bin/gosu /usr/local/bin/su-exec; \
     su-exec nobody true; \
+    \
+# Install tini
+    wget -O tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64"; \
+    wget -O tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$TINI_GPG_KEY"; \
+    gpg --batch --verify tini.asc tini; \
+    rm -r "$GNUPGHOME" tini.asc; \
+    chmod +x tini; \
+    mv tini /usr/local/sbin/tini; \
+# Link `tini` as `dumb-init` and `dinit` for compatibility with older images
+    ln -s /usr/local/sbin/tini /usr/local/sbin/dumb-init; \
+    dumb-init -s -- true; \
+    ln -s /usr/local/sbin/tini /usr/local/sbin/dinit; \
+    dinit -s -- true; \
+    \
     apt-get-purge.sh wget
 
 # Set dinit as the default entrypoint
-ENTRYPOINT ["dinit"]
+ENTRYPOINT ["tini"]
 CMD ["pypy"]

--- a/debian/pypy/3/Dockerfile
+++ b/debian/pypy/3/Dockerfile
@@ -51,6 +51,6 @@ RUN set -xe; \
     \
     apt-get-purge.sh wget
 
-# Set dinit as the default entrypoint
+# Set tini as the default entrypoint
 ENTRYPOINT ["tini"]
 CMD ["pypy3"]

--- a/debian/pypy/3/Dockerfile
+++ b/debian/pypy/3/Dockerfile
@@ -14,19 +14,13 @@ RUN update-alternatives --install /usr/local/bin/pypy pypy /usr/local/bin/pypy3 
 COPY scripts /scripts
 ENV PATH $PATH:/scripts
 
-ENV DINIT_VERSION="1.2.0" \
-    DINIT_SHA256="9af7440986893c904f24c086c50846ddc5a0f24864f5566b747b8f1a17f7fd52"
 ENV GOSU_VERSION="1.10" \
-    GOSU_GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4"
+    GOSU_GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    TINI_VERSION="0.14.0" \
+    TINI_GPG_KEY="595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7"
 RUN set -xe; \
     apt-get-install.sh wget; \
-# Install dumb-init
-    wget -O dumb-init.deb "https://github.com/Yelp/dumb-init/releases/download/v$DINIT_VERSION/dumb-init_${DINIT_VERSION}_amd64.deb"; \
-    echo "$DINIT_SHA256 *dumb-init.deb" | sha256sum -c -; \
-    dpkg --install dumb-init.deb; \
-    rm dumb-init.deb; \
-    ln -s $(which dumb-init) /usr/local/bin/dinit; \
-    dinit true; \
+    \
 # Install gosu
     wget -O gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64"; \
     wget -O gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc"; \
@@ -36,10 +30,27 @@ RUN set -xe; \
     rm -r "$GNUPGHOME" gosu.asc; \
     chmod +x gosu; \
     mv gosu /usr/local/bin/gosu; \
+# Link `gosu` as `su-exec` for compatibility with Alpine Linux
     ln -s /usr/local/bin/gosu /usr/local/bin/su-exec; \
     su-exec nobody true; \
+    \
+# Install tini
+    wget -O tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64"; \
+    wget -O tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$TINI_GPG_KEY"; \
+    gpg --batch --verify tini.asc tini; \
+    rm -r "$GNUPGHOME" tini.asc; \
+    chmod +x tini; \
+    mv tini /usr/local/sbin/tini; \
+# Link `tini` as `dumb-init` and `dinit` for compatibility with older images
+    ln -s /usr/local/sbin/tini /usr/local/sbin/dumb-init; \
+    dumb-init -s -- true; \
+    ln -s /usr/local/sbin/tini /usr/local/sbin/dinit; \
+    dinit -s -- true; \
+    \
     apt-get-purge.sh wget
 
 # Set dinit as the default entrypoint
-ENTRYPOINT ["dinit"]
+ENTRYPOINT ["tini"]
 CMD ["pypy3"]

--- a/debian/pypy/3/Dockerfile
+++ b/debian/pypy/3/Dockerfile
@@ -29,9 +29,9 @@ RUN set -xe; \
     gpg --batch --verify gosu.asc gosu; \
     rm -r "$GNUPGHOME" gosu.asc; \
     chmod +x gosu; \
-    mv gosu /usr/local/bin/gosu; \
+    mv gosu /usr/local/sbin/gosu; \
 # Link `gosu` as `su-exec` for compatibility with Alpine Linux
-    ln -s /usr/local/bin/gosu /usr/local/bin/su-exec; \
+    ln -s /usr/local/sbin/gosu /usr/local/sbin/su-exec; \
     su-exec nobody true; \
     \
 # Install tini

--- a/debian/python/2.7/Dockerfile
+++ b/debian/python/2.7/Dockerfile
@@ -9,19 +9,13 @@ ENV PIP_NO_CACHE_DIR="false" \
 COPY scripts /scripts
 ENV PATH $PATH:/scripts
 
-ENV DINIT_VERSION="1.2.0" \
-    DINIT_SHA256="9af7440986893c904f24c086c50846ddc5a0f24864f5566b747b8f1a17f7fd52"
 ENV GOSU_VERSION="1.10" \
-    GOSU_GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4"
+    GOSU_GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    TINI_VERSION="0.14.0" \
+    TINI_GPG_KEY="595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7"
 RUN set -xe; \
     apt-get-install.sh wget; \
-# Install dumb-init
-    wget -O dumb-init.deb "https://github.com/Yelp/dumb-init/releases/download/v$DINIT_VERSION/dumb-init_${DINIT_VERSION}_amd64.deb"; \
-    echo "$DINIT_SHA256 *dumb-init.deb" | sha256sum -c -; \
-    dpkg --install dumb-init.deb; \
-    rm dumb-init.deb; \
-    ln -s $(which dumb-init) /usr/local/bin/dinit; \
-    dinit true; \
+    \
 # Install gosu
     wget -O gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64"; \
     wget -O gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc"; \
@@ -31,10 +25,27 @@ RUN set -xe; \
     rm -r "$GNUPGHOME" gosu.asc; \
     chmod +x gosu; \
     mv gosu /usr/local/bin/gosu; \
+# Link `gosu` as `su-exec` for compatibility with Alpine Linux
     ln -s /usr/local/bin/gosu /usr/local/bin/su-exec; \
     su-exec nobody true; \
+    \
+# Install tini
+    wget -O tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64"; \
+    wget -O tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$TINI_GPG_KEY"; \
+    gpg --batch --verify tini.asc tini; \
+    rm -r "$GNUPGHOME" tini.asc; \
+    chmod +x tini; \
+    mv tini /usr/local/sbin/tini; \
+# Link `tini` as `dumb-init` and `dinit` for compatibility with older images
+    ln -s /usr/local/sbin/tini /usr/local/sbin/dumb-init; \
+    dumb-init -s -- true; \
+    ln -s /usr/local/sbin/tini /usr/local/sbin/dinit; \
+    dinit -s -- true; \
+    \
     apt-get-purge.sh wget
 
 # Set dinit as the default entrypoint
-ENTRYPOINT ["dinit"]
+ENTRYPOINT ["tini"]
 CMD ["python"]

--- a/debian/python/2.7/Dockerfile
+++ b/debian/python/2.7/Dockerfile
@@ -24,9 +24,9 @@ RUN set -xe; \
     gpg --batch --verify gosu.asc gosu; \
     rm -r "$GNUPGHOME" gosu.asc; \
     chmod +x gosu; \
-    mv gosu /usr/local/bin/gosu; \
+    mv gosu /usr/local/sbin/gosu; \
 # Link `gosu` as `su-exec` for compatibility with Alpine Linux
-    ln -s /usr/local/bin/gosu /usr/local/bin/su-exec; \
+    ln -s /usr/local/sbin/gosu /usr/local/sbin/su-exec; \
     su-exec nobody true; \
     \
 # Install tini

--- a/debian/python/3.6/Dockerfile
+++ b/debian/python/3.6/Dockerfile
@@ -9,19 +9,13 @@ ENV PIP_NO_CACHE_DIR="false" \
 COPY scripts /scripts
 ENV PATH $PATH:/scripts
 
-ENV DINIT_VERSION="1.2.0" \
-    DINIT_SHA256="9af7440986893c904f24c086c50846ddc5a0f24864f5566b747b8f1a17f7fd52"
 ENV GOSU_VERSION="1.10" \
-    GOSU_GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4"
+    GOSU_GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    TINI_VERSION="0.14.0" \
+    TINI_GPG_KEY="595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7"
 RUN set -xe; \
     apt-get-install.sh wget; \
-# Install dumb-init
-    wget -O dumb-init.deb "https://github.com/Yelp/dumb-init/releases/download/v$DINIT_VERSION/dumb-init_${DINIT_VERSION}_amd64.deb"; \
-    echo "$DINIT_SHA256 *dumb-init.deb" | sha256sum -c -; \
-    dpkg --install dumb-init.deb; \
-    rm dumb-init.deb; \
-    ln -s $(which dumb-init) /usr/local/bin/dinit; \
-    dinit true; \
+    \
 # Install gosu
     wget -O gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64"; \
     wget -O gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc"; \
@@ -31,8 +25,25 @@ RUN set -xe; \
     rm -r "$GNUPGHOME" gosu.asc; \
     chmod +x gosu; \
     mv gosu /usr/local/bin/gosu; \
+# Link `gosu` as `su-exec` for compatibility with Alpine Linux
     ln -s /usr/local/bin/gosu /usr/local/bin/su-exec; \
     su-exec nobody true; \
+    \
+# Install tini
+    wget -O tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64"; \
+    wget -O tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$TINI_GPG_KEY"; \
+    gpg --batch --verify tini.asc tini; \
+    rm -r "$GNUPGHOME" tini.asc; \
+    chmod +x tini; \
+    mv tini /usr/local/sbin/tini; \
+# Link `tini` as `dumb-init` and `dinit` for compatibility with older images
+    ln -s /usr/local/sbin/tini /usr/local/sbin/dumb-init; \
+    dumb-init -s -- true; \
+    ln -s /usr/local/sbin/tini /usr/local/sbin/dinit; \
+    dinit -s -- true; \
+    \
     apt-get-purge.sh wget
 
 # Set dinit as the default entrypoint

--- a/debian/python/3.6/Dockerfile
+++ b/debian/python/3.6/Dockerfile
@@ -24,9 +24,9 @@ RUN set -xe; \
     gpg --batch --verify gosu.asc gosu; \
     rm -r "$GNUPGHOME" gosu.asc; \
     chmod +x gosu; \
-    mv gosu /usr/local/bin/gosu; \
+    mv gosu /usr/local/sbin/gosu; \
 # Link `gosu` as `su-exec` for compatibility with Alpine Linux
-    ln -s /usr/local/bin/gosu /usr/local/bin/su-exec; \
+    ln -s /usr/local/sbin/gosu /usr/local/sbin/su-exec; \
     su-exec nobody true; \
     \
 # Install tini


### PR DESCRIPTION
* tini will happen automatically with Docker 1.13.0+ and then we can
  remove the init system from the image completely
* I want to make sure there are no compatibility issues with it
* tini is a much better name than dumb-init