### PR TITLE
Add --force-confnew to apt-get install

### DIFF
--- a/debian/scripts/apt-get-install.sh
+++ b/debian/scripts/apt-get-install.sh
@@ -12,6 +12,7 @@ apt-get update
 apt-get install -y \
   -o APT::Install-Recommends=false \
   -o APT::Install-Suggests=false \
+  -o Dpkg::Options::="--force-confnew" \
   "$@"
 
 # Remove the package indexes


### PR DESCRIPTION
When apt has a problem installing a package because a config file has changed, it will ask the user what to do. This requires stdin which breaks the downstream container build.

I think (though this is a bit of a guess) that we'll always want the new, packaged version of the config file.